### PR TITLE
Bump runtime version to 21.08 to get python 3.9

### DIFF
--- a/com.jetbrains.PyCharm-Professional.yaml
+++ b/com.jetbrains.PyCharm-Professional.yaml
@@ -1,6 +1,6 @@
 app-id: com.jetbrains.PyCharm-Professional
 runtime: org.freedesktop.Sdk
-runtime-version: '20.08'
+runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 command: pycharm
 separate-locales: false


### PR DESCRIPTION
freedesktop releases update to runtime. 
https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/release/21.08/NEWS

Main changes for us is python 3.9