### PR TITLE
Bump poetry to 1.2.0. Prepare to be rust ready

### DIFF
--- a/cargo-sources.json
+++ b/cargo-sources.json
@@ -1,0 +1,593 @@
+[
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/Inflector/Inflector-0.11.4.crate",
+        "sha256": "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3",
+        "dest": "cargo/vendor/Inflector-0.11.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3\", \"files\": {}}",
+        "dest": "cargo/vendor/Inflector-0.11.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/aliasable/aliasable-0.1.3.crate",
+        "sha256": "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd",
+        "dest": "cargo/vendor/aliasable-0.1.3"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd\", \"files\": {}}",
+        "dest": "cargo/vendor/aliasable-0.1.3",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/asn1/asn1-0.8.7.crate",
+        "sha256": "cfffb35195feaeffb071af0f7a643405667813dd8629c27cb0c310fb76654ab1",
+        "dest": "cargo/vendor/asn1-0.8.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"cfffb35195feaeffb071af0f7a643405667813dd8629c27cb0c310fb76654ab1\", \"files\": {}}",
+        "dest": "cargo/vendor/asn1-0.8.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/asn1_derive/asn1_derive-0.8.7.crate",
+        "sha256": "bc894fa05f786b6481065514e6ff5e1838a3362f543f71f6e1a92ff27b051c25",
+        "dest": "cargo/vendor/asn1_derive-0.8.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bc894fa05f786b6481065514e6ff5e1838a3362f543f71f6e1a92ff27b051c25\", \"files\": {}}",
+        "dest": "cargo/vendor/asn1_derive-0.8.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/autocfg/autocfg-1.1.0.crate",
+        "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
+        "dest": "cargo/vendor/autocfg-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa\", \"files\": {}}",
+        "dest": "cargo/vendor/autocfg-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/base64/base64-0.13.0.crate",
+        "sha256": "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd",
+        "dest": "cargo/vendor/base64-0.13.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd\", \"files\": {}}",
+        "dest": "cargo/vendor/base64-0.13.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/bitflags/bitflags-1.3.2.crate",
+        "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
+        "dest": "cargo/vendor/bitflags-1.3.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a\", \"files\": {}}",
+        "dest": "cargo/vendor/bitflags-1.3.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/cfg-if/cfg-if-1.0.0.crate",
+        "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
+        "dest": "cargo/vendor/cfg-if-1.0.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd\", \"files\": {}}",
+        "dest": "cargo/vendor/cfg-if-1.0.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/chrono/chrono-0.4.19.crate",
+        "sha256": "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73",
+        "dest": "cargo/vendor/chrono-0.4.19"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73\", \"files\": {}}",
+        "dest": "cargo/vendor/chrono-0.4.19",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/indoc/indoc-0.3.6.crate",
+        "sha256": "47741a8bc60fb26eb8d6e0238bbb26d8575ff623fdc97b1a2c00c050b9684ed8",
+        "dest": "cargo/vendor/indoc-0.3.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"47741a8bc60fb26eb8d6e0238bbb26d8575ff623fdc97b1a2c00c050b9684ed8\", \"files\": {}}",
+        "dest": "cargo/vendor/indoc-0.3.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/indoc-impl/indoc-impl-0.3.6.crate",
+        "sha256": "ce046d161f000fffde5f432a0d034d0341dc152643b2598ed5bfce44c4f3a8f0",
+        "dest": "cargo/vendor/indoc-impl-0.3.6"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ce046d161f000fffde5f432a0d034d0341dc152643b2598ed5bfce44c4f3a8f0\", \"files\": {}}",
+        "dest": "cargo/vendor/indoc-impl-0.3.6",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/instant/instant-0.1.12.crate",
+        "sha256": "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c",
+        "dest": "cargo/vendor/instant-0.1.12"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c\", \"files\": {}}",
+        "dest": "cargo/vendor/instant-0.1.12",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lazy_static/lazy_static-1.4.0.crate",
+        "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
+        "dest": "cargo/vendor/lazy_static-1.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646\", \"files\": {}}",
+        "dest": "cargo/vendor/lazy_static-1.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/libc/libc-0.2.124.crate",
+        "sha256": "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50",
+        "dest": "cargo/vendor/libc-0.2.124"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50\", \"files\": {}}",
+        "dest": "cargo/vendor/libc-0.2.124",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/lock_api/lock_api-0.4.7.crate",
+        "sha256": "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53",
+        "dest": "cargo/vendor/lock_api-0.4.7"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53\", \"files\": {}}",
+        "dest": "cargo/vendor/lock_api-0.4.7",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-integer/num-integer-0.1.44.crate",
+        "sha256": "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db",
+        "dest": "cargo/vendor/num-integer-0.1.44"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db\", \"files\": {}}",
+        "dest": "cargo/vendor/num-integer-0.1.44",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/num-traits/num-traits-0.2.14.crate",
+        "sha256": "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290",
+        "dest": "cargo/vendor/num-traits-0.2.14"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290\", \"files\": {}}",
+        "dest": "cargo/vendor/num-traits-0.2.14",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/once_cell/once_cell-1.10.0.crate",
+        "sha256": "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9",
+        "dest": "cargo/vendor/once_cell-1.10.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9\", \"files\": {}}",
+        "dest": "cargo/vendor/once_cell-1.10.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ouroboros/ouroboros-0.15.0.crate",
+        "sha256": "9f31a3b678685b150cba82b702dcdc5e155893f63610cf388d30cd988d4ca2bf",
+        "dest": "cargo/vendor/ouroboros-0.15.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"9f31a3b678685b150cba82b702dcdc5e155893f63610cf388d30cd988d4ca2bf\", \"files\": {}}",
+        "dest": "cargo/vendor/ouroboros-0.15.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/ouroboros_macro/ouroboros_macro-0.15.0.crate",
+        "sha256": "084fd65d5dd8b3772edccb5ffd1e4b7eba43897ecd0f9401e330e8c542959408",
+        "dest": "cargo/vendor/ouroboros_macro-0.15.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"084fd65d5dd8b3772edccb5ffd1e4b7eba43897ecd0f9401e330e8c542959408\", \"files\": {}}",
+        "dest": "cargo/vendor/ouroboros_macro-0.15.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/parking_lot/parking_lot-0.11.2.crate",
+        "sha256": "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99",
+        "dest": "cargo/vendor/parking_lot-0.11.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99\", \"files\": {}}",
+        "dest": "cargo/vendor/parking_lot-0.11.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.8.5.crate",
+        "sha256": "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216",
+        "dest": "cargo/vendor/parking_lot_core-0.8.5"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216\", \"files\": {}}",
+        "dest": "cargo/vendor/parking_lot_core-0.8.5",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/paste/paste-0.1.18.crate",
+        "sha256": "45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880",
+        "dest": "cargo/vendor/paste-0.1.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"45ca20c77d80be666aef2b45486da86238fabe33e38306bd3118fe4af33fa880\", \"files\": {}}",
+        "dest": "cargo/vendor/paste-0.1.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/paste-impl/paste-impl-0.1.18.crate",
+        "sha256": "d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6",
+        "dest": "cargo/vendor/paste-impl-0.1.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d95a7db200b97ef370c8e6de0088252f7e0dfff7d047a28528e47456c0fc98b6\", \"files\": {}}",
+        "dest": "cargo/vendor/paste-impl-0.1.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pem/pem-1.0.2.crate",
+        "sha256": "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947",
+        "dest": "cargo/vendor/pem-1.0.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947\", \"files\": {}}",
+        "dest": "cargo/vendor/pem-1.0.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-error/proc-macro-error-1.0.4.crate",
+        "sha256": "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c",
+        "dest": "cargo/vendor/proc-macro-error-1.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-error-1.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-error-attr/proc-macro-error-attr-1.0.4.crate",
+        "sha256": "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869",
+        "dest": "cargo/vendor/proc-macro-error-attr-1.0.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-error-attr-1.0.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro-hack/proc-macro-hack-0.5.19.crate",
+        "sha256": "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5",
+        "dest": "cargo/vendor/proc-macro-hack-0.5.19"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro-hack-0.5.19",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.37.crate",
+        "sha256": "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1",
+        "dest": "cargo/vendor/proc-macro2-1.0.37"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1\", \"files\": {}}",
+        "dest": "cargo/vendor/proc-macro2-1.0.37",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pyo3/pyo3-0.15.2.crate",
+        "sha256": "d41d50a7271e08c7c8a54cd24af5d62f73ee3a6f6a314215281ebdec421d5752",
+        "dest": "cargo/vendor/pyo3-0.15.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d41d50a7271e08c7c8a54cd24af5d62f73ee3a6f6a314215281ebdec421d5752\", \"files\": {}}",
+        "dest": "cargo/vendor/pyo3-0.15.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pyo3-build-config/pyo3-build-config-0.15.2.crate",
+        "sha256": "779239fc40b8e18bc8416d3a37d280ca9b9fb04bda54b98037bb6748595c2410",
+        "dest": "cargo/vendor/pyo3-build-config-0.15.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"779239fc40b8e18bc8416d3a37d280ca9b9fb04bda54b98037bb6748595c2410\", \"files\": {}}",
+        "dest": "cargo/vendor/pyo3-build-config-0.15.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pyo3-macros/pyo3-macros-0.15.2.crate",
+        "sha256": "00b247e8c664be87998d8628e86f282c25066165f1f8dda66100c48202fdb93a",
+        "dest": "cargo/vendor/pyo3-macros-0.15.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"00b247e8c664be87998d8628e86f282c25066165f1f8dda66100c48202fdb93a\", \"files\": {}}",
+        "dest": "cargo/vendor/pyo3-macros-0.15.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/pyo3-macros-backend/pyo3-macros-backend-0.15.2.crate",
+        "sha256": "5a8c2812c412e00e641d99eeb79dd478317d981d938aa60325dfa7157b607095",
+        "dest": "cargo/vendor/pyo3-macros-backend-0.15.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5a8c2812c412e00e641d99eeb79dd478317d981d938aa60325dfa7157b607095\", \"files\": {}}",
+        "dest": "cargo/vendor/pyo3-macros-backend-0.15.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/quote/quote-1.0.18.crate",
+        "sha256": "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1",
+        "dest": "cargo/vendor/quote-1.0.18"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1\", \"files\": {}}",
+        "dest": "cargo/vendor/quote-1.0.18",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.2.13.crate",
+        "sha256": "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42",
+        "dest": "cargo/vendor/redox_syscall-0.2.13"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42\", \"files\": {}}",
+        "dest": "cargo/vendor/redox_syscall-0.2.13",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/scopeguard/scopeguard-1.1.0.crate",
+        "sha256": "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
+        "dest": "cargo/vendor/scopeguard-1.1.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd\", \"files\": {}}",
+        "dest": "cargo/vendor/scopeguard-1.1.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/smallvec/smallvec-1.8.0.crate",
+        "sha256": "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83",
+        "dest": "cargo/vendor/smallvec-1.8.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83\", \"files\": {}}",
+        "dest": "cargo/vendor/smallvec-1.8.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/stable_deref_trait/stable_deref_trait-1.2.0.crate",
+        "sha256": "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3",
+        "dest": "cargo/vendor/stable_deref_trait-1.2.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3\", \"files\": {}}",
+        "dest": "cargo/vendor/stable_deref_trait-1.2.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/syn/syn-1.0.91.crate",
+        "sha256": "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d",
+        "dest": "cargo/vendor/syn-1.0.91"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d\", \"files\": {}}",
+        "dest": "cargo/vendor/syn-1.0.91",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unicode-xid/unicode-xid-0.2.2.crate",
+        "sha256": "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3",
+        "dest": "cargo/vendor/unicode-xid-0.2.2"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3\", \"files\": {}}",
+        "dest": "cargo/vendor/unicode-xid-0.2.2",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/unindent/unindent-0.1.8.crate",
+        "sha256": "514672a55d7380da379785a4d70ca8386c8883ff7eaae877be4d2081cebe73d8",
+        "dest": "cargo/vendor/unindent-0.1.8"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"514672a55d7380da379785a4d70ca8386c8883ff7eaae877be4d2081cebe73d8\", \"files\": {}}",
+        "dest": "cargo/vendor/unindent-0.1.8",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/version_check/version_check-0.9.4.crate",
+        "sha256": "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f",
+        "dest": "cargo/vendor/version_check-0.9.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f\", \"files\": {}}",
+        "dest": "cargo/vendor/version_check-0.9.4",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi/winapi-0.3.9.crate",
+        "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+        "dest": "cargo/vendor/winapi-0.3.9"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-0.3.9",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate",
+        "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
+        "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
+        "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+        "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f\", \"files\": {}}",
+        "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0",
+        "dest-filename": ".cargo-checksum.json"
+    },
+    {
+        "type": "inline",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n",
+        "dest": "cargo",
+        "dest-filename": "config"
+    }
+]

--- a/com.jetbrains.PyCharm-Professional.yaml
+++ b/com.jetbrains.PyCharm-Professional.yaml
@@ -2,6 +2,8 @@ app-id: com.jetbrains.PyCharm-Professional
 runtime: org.freedesktop.Sdk
 runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.rust-stable
 command: pycharm
 separate-locales: false
 finish-args:

--- a/python3-pipenv.yaml
+++ b/python3-pipenv.yaml
@@ -6,20 +6,6 @@ build-commands:
     --prefix=${FLATPAK_DEST} "pipenv" --no-build-isolation
 sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/a6/d5/17f02b379525d1ff9678bfa58eb9548f561c8826deb0b85797aa0eed582d/filelock-3.7.1-py3-none-any.whl
-    sha256: 37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404
-    x-checker-data:
-      name: filelock
-      packagetype: bdist_wheel
-      type: pypi
-  - type: file
-    url: https://files.pythonhosted.org/packages/d5/94/db0229ff741c8ff2ff0ac5a8a58d142bd0f81c810701ad9eae2c4c718ede/distlib-0.3.5-py2.py3-none-any.whl
-    sha256: b710088c59f06338ca514800ad795a132da19fda270e3ce4affc74abf955a26c
-    x-checker-data:
-      name: distlib
-      packagetype: bdist_wheel
-      type: pypi
-  - type: file
     url: https://files.pythonhosted.org/packages/e9/06/d3d367b7af6305b16f0d28ae2aaeb86154fa91f144f036c2d5002a5a202b/certifi-2022.6.15-py3-none-any.whl
     sha256: fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412
     x-checker-data:
@@ -27,17 +13,10 @@ sources:
       packagetype: bdist_wheel
       type: pypi
   - type: file
-    url: https://files.pythonhosted.org/packages/c2/d2/e80b6ad57bc0727fe0bbe7d9c496bde4ef3008e57f452ed1bfafe6618d04/virtualenv-20.16.3-py2.py3-none-any.whl
-    sha256: 4193b7bc8a6cd23e4eb251ac64f29b4398ab2c233531e66e40b19a6b7b0d30c1
+    url: https://files.pythonhosted.org/packages/94/b3/ff2845971788613e646e667043fdb5f128e2e540aefa09a3c55be8290d6d/filelock-3.8.0-py3-none-any.whl
+    sha256: 617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4
     x-checker-data:
-      name: virtualenv
-      packagetype: bdist_wheel
-      type: pypi
-  - type: file
-    url: https://files.pythonhosted.org/packages/b4/40/5af97bfd06644bca952bd4c9289290c85c2b5db72b4119feb6969d72f7b8/pipenv-2022.8.5-py2.py3-none-any.whl
-    sha256: e9333cdd365aeb9c3f9460ac2d84c4750e3ffa8e766fe3d5de03d4496b55d851
-    x-checker-data:
-      name: pipenv
+      name: filelock
       packagetype: bdist_wheel
       type: pypi
   - type: file
@@ -48,9 +27,30 @@ sources:
       packagetype: bdist_wheel
       type: pypi
   - type: file
+    url: https://files.pythonhosted.org/packages/92/70/61759c5239a81fdb07432e0a1f10311da5e09cd7e8148155272bfa116a64/pipenv-2022.8.30-py2.py3-none-any.whl
+    sha256: 129b688c3de53e4a454346b7a0c45385ab811260faaa3431ae774f0c55e95a9a
+    x-checker-data:
+      name: pipenv
+      packagetype: bdist_wheel
+      type: pypi
+  - type: file
     url: https://files.pythonhosted.org/packages/ed/22/967181c94c3a4063fe64e15331b4cb366bdd7dfbf46fcb8ad89650026fec/platformdirs-2.5.2-py3-none-any.whl
     sha256: 027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788
     x-checker-data:
       name: platformdirs
+      packagetype: bdist_wheel
+      type: pypi
+  - type: file
+    url: https://files.pythonhosted.org/packages/4f/8c/2f44bb00c152f24d980c91b95c0b0f38f814eb5b7a7da102467d23749ee3/virtualenv-20.16.4-py3-none-any.whl
+    sha256: 035ed57acce4ac35c82c9d8802202b0e71adac011a511ff650cbcf9635006a22
+    x-checker-data:
+      name: virtualenv
+      packagetype: bdist_wheel
+      type: pypi
+  - type: file
+    url: https://files.pythonhosted.org/packages/76/cb/6bbd2b10170ed991cf64e8c8b85e01f2fb38f95d1bc77617569e0b0b26ac/distlib-0.3.6-py2.py3-none-any.whl
+    sha256: f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e
+    x-checker-data:
+      name: distlib
       packagetype: bdist_wheel
       type: pypi

--- a/python3-poetry.yaml
+++ b/python3-poetry.yaml
@@ -1,16 +1,52 @@
-# Generated with flatpak-pip-generator cryptography==3.4.8 poetry==1.1.14 --runtime com.jetbrains.PyCharm-Professional --checker-data --yaml
+# Generated with flatpak-pip-generator cryptography==3.4.8 poetry --runtime com.jetbrains.PyCharm-Professional --checker-data --yaml
 # Must be patched to install old version of cryptography
 #
-#
+# building cargo-sources.
+# retrive https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/cargo/flatpak-cargo-generator.py
+# download needed cryptography version, unpack
+# ./flatpak-cargo-generator.py cryptography-37.0.4/src/rust/Cargo.lock
 build-commands: []
 buildsystem: simple
 modules:
-  - name: python3-cryptography
+  # Generated with flatpak-pip-generator setuptools_rust==1.3.0 --runtime com.jetbrains.PyCharm-Professional --checker-data --yaml
+  # version newer than 1.3.0 fails with
+  # No matching distribution found for setuptools>=62.4
+  - name: python3-setuptools_rust
     buildsystem: simple
     build-commands:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "cryptography==3.4.8" --no-build-isolation
+        --prefix=${FLATPAK_DEST} "setuptools_rust" --no-build-isolation
     sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/ed/d6/2afc375a8d55b8be879d6b4986d4f69f01115e795e36827fd3a40166028b/typing_extensions-4.3.0-py3-none-any.whl
+        sha256: 25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02
+        x-checker-data:
+          name: typing_extensions
+          packagetype: bdist_wheel
+          type: pypi
+      - type: file
+        url: https://files.pythonhosted.org/packages/be/19/a9356aac40b2432cd159264be98843af062877ff27422cdd7cf023828835/setuptools_rust-1.3.0-py3-none-any.whl
+        sha256: 7ead7398d6b6fe70a7743408dc2f7257dbcb8ca9b2d7a9f8b281c09bd86f36a5
+      - type: file
+        url: https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl
+        sha256: de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177
+        x-checker-data:
+          name: semantic_version
+          packagetype: bdist_wheel
+          type: pypi
+  - name: python3-cryptography
+    build-options:
+      append-path: /usr/lib/sdk/rust-stable/bin
+      env:
+        CARGO_HOME: /run/build/python3-cryptography/cargo
+        CARGO_NET_OFFLINE: 'true'
+        RUST_BACKTRACE: '1'
+    buildsystem: simple
+    build-commands:
+      - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
+        --prefix=${FLATPAK_DEST} "cryptography" --no-build-isolation
+    sources:
+      - cargo-sources.json
       - &id002
         type: file
         url: https://files.pythonhosted.org/packages/2b/a8/050ab4f0c3d4c1b8aaa805f70e26e84d0e27004907c5b8ecc1d31815f92a/cffi-1.15.1.tar.gz
@@ -20,11 +56,11 @@ modules:
           type: pypi
       - &id001
         type: file
-        url: https://files.pythonhosted.org/packages/96/07/4d23f8e34e56d8eeb2c37cd5924928a01c3dd756a1d99e470181bc57551e/cryptography-3.4.8-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-        sha256: 1eb7bb0df6f6f583dd8e054689def236255161ebbcf62b226454ab9ec663746b
-#        x-checker-data:
-#          name: cryptography
-#          type: pypi
+        url: https://files.pythonhosted.org/packages/89/d9/5fcd312d5cce0b4d7ee8b551a0ea99e4ea9db0fdbf6dd455a19042e3370b/cryptography-37.0.4.tar.gz
+        sha256: 63f9c17c0e2474ccbebc9302ce2f07b55b3b3fcb211ded18a42d5764f5c10a82
+        x-checker-data:
+          name: cryptography
+          type: pypi
       - &id003
         type: file
         url: https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl
@@ -37,8 +73,21 @@ modules:
     buildsystem: simple
     build-commands:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "poetry==1.1.14" --no-build-isolation
+        --prefix=${FLATPAK_DEST} "poetry" --no-build-isolation
     sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/42/ac/455fdc7294acc4d4154b904e80d964cc9aae75b087bbf486be04df9f2abd/pyrsistent-0.18.1.tar.gz
+        sha256: d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96
+        x-checker-data:
+          name: pyrsistent
+          type: pypi
+      - type: file
+        url: https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl
+        sha256: f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99
+        x-checker-data:
+          name: SecretStorage
+          packagetype: bdist_wheel
+          type: pypi
       - type: file
         url: https://files.pythonhosted.org/packages/04/a2/d918dcd22354d8958fe113e1a3630137e0fc8b44859ade3063982eacd2a4/idna-3.3-py3-none-any.whl
         sha256: 84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff
@@ -47,24 +96,24 @@ modules:
           packagetype: bdist_wheel
           type: pypi
       - type: file
-        url: https://files.pythonhosted.org/packages/a6/d5/17f02b379525d1ff9678bfa58eb9548f561c8826deb0b85797aa0eed582d/filelock-3.7.1-py3-none-any.whl
-        sha256: 37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404
-        x-checker-data:
-          name: filelock
-          packagetype: bdist_wheel
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/d5/94/db0229ff741c8ff2ff0ac5a8a58d142bd0f81c810701ad9eae2c4c718ede/distlib-0.3.5-py2.py3-none-any.whl
-        sha256: b710088c59f06338ca514800ad795a132da19fda270e3ce4affc74abf955a26c
-        x-checker-data:
-          name: distlib
-          packagetype: bdist_wheel
-          type: pypi
-      - type: file
         url: https://files.pythonhosted.org/packages/76/97/2a99f020be5e4a5a97ba10bc480e2e6a889b5087103a2c6b952b5f819d27/crashtest-0.3.1-py3-none-any.whl
         sha256: 300f4b0825f57688b47b6d70c6a31de33512eb2fa1ac614f780939aa0cf91680
         x-checker-data:
           name: crashtest
+          packagetype: bdist_wheel
+          type: pypi
+      - type: file
+        url: https://files.pythonhosted.org/packages/45/0c/3825603bf62f360829b1eea29a43dadce30829067e288170b3bf738aafd0/cleo-1.0.0a5-py3-none-any.whl
+        sha256: ff53056589300976e960f75afb792dfbfc9c78dcbb5a448e207a17b643826360
+        x-checker-data:
+          name: cleo
+          packagetype: bdist_wheel
+          type: pypi
+      - type: file
+        url: https://files.pythonhosted.org/packages/fa/1a/928afa4256942608bd4a4d4ed4452ce12de1b4e6e4a36b7e67c73cb1b82c/poetry_core-1.1.0-py3-none-any.whl
+        sha256: da16a12054bf3f1ff8656d4c289f99c3d6b7704d272fb174004c4dc82e045954
+        x-checker-data:
+          name: poetry_core
           packagetype: bdist_wheel
           type: pypi
       - type: file
@@ -96,6 +145,20 @@ modules:
           packagetype: bdist_wheel
           type: pypi
       - type: file
+        url: https://files.pythonhosted.org/packages/11/fe/20cbff273341943e6f9f1c5b5f7a09be9eb51cc7e169e53980292ce273a4/jsonschema-4.15.0-py3-none-any.whl
+        sha256: 2df0fab225abb3b41967bb3a46fd37dc74b1536b5296d0b1c2078cd072adf0f7
+        x-checker-data:
+          name: jsonschema
+          packagetype: bdist_wheel
+          type: pypi
+      - type: file
+        url: https://files.pythonhosted.org/packages/05/8e/8de486cbd03baba4deef4142bd643a3e7bbe954a784dc1bb17142572d127/packaging-21.3-py3-none-any.whl
+        sha256: ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522
+        x-checker-data:
+          name: packaging
+          packagetype: bdist_wheel
+          type: pypi
+      - type: file
         url: https://files.pythonhosted.org/packages/82/e6/badd9af6feee43e76c3445b2621a60d3d99fe0e33fffa8df43590212ea63/cachy-0.3.0-py2.py3-none-any.whl
         sha256: 338ca09c8860e76b275aff52374330efedc4d5a5e45dc1c5b539c1ead0786fe7
         x-checker-data:
@@ -111,18 +174,10 @@ modules:
           packagetype: bdist_wheel
           type: pypi
       - type: file
-        url: https://files.pythonhosted.org/packages/54/42/7cf083c31a9739b40ed683fad17460d1db97ecd23c344df25e41fa9e85e2/SecretStorage-3.3.2-py3-none-any.whl
-        sha256: 755dc845b6ad76dcbcbc07ea3da75ae54bb1ea529eb72d15f83d26499a5df319
+        url: https://files.pythonhosted.org/packages/8e/99/7f139ec0e9d224542115ef070c79503bcb271edaaf0c1e049a5fbdaad6a5/dulwich-0.20.45.tar.gz
+        sha256: 70710dd9ca2a442190c7e506892db074c318ac762e221f7529b8ce34802041b7
         x-checker-data:
-          name: SecretStorage
-          packagetype: bdist_wheel
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/c2/d2/e80b6ad57bc0727fe0bbe7d9c496bde4ef3008e57f452ed1bfafe6618d04/virtualenv-20.16.3-py2.py3-none-any.whl
-        sha256: 4193b7bc8a6cd23e4eb251ac64f29b4398ab2c233531e66e40b19a6b7b0d30c1
-        x-checker-data:
-          name: virtualenv
-          packagetype: bdist_wheel
+          name: dulwich
           type: pypi
       - type: file
         url: https://files.pythonhosted.org/packages/39/7b/88dbb785881c28a102619d46423cb853b46dbccc70d3ac362d99773a78ce/pexpect-4.8.0-py2.py3-none-any.whl
@@ -131,14 +186,14 @@ modules:
           name: pexpect
           packagetype: bdist_wheel
           type: pypi
-      - *id002
       - type: file
-        url: https://files.pythonhosted.org/packages/3e/89/7ea760b4daa42653ece2380531c90f64788d979110a2ab51049d92f408af/packaging-20.9-py2.py3-none-any.whl
-        sha256: 67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a
+        url: https://files.pythonhosted.org/packages/23/d0/8fa7a78b125d6da7e6bf602be8bcdd68bd92f9021c28dc3769a340fd587e/poetry_plugin_export-1.0.6-py3-none-any.whl
+        sha256: 55ae87d4560a6a3f96e04eba63c78cadbd0410e9652dee0ee1cde93281e9cb48
         x-checker-data:
-          name: packaging
+          name: poetry_plugin_export
           packagetype: bdist_wheel
           type: pypi
+      - *id002
       - type: file
         url: https://files.pythonhosted.org/packages/3d/1a/d31fce69c119df1fddab3706b63c53d363982c55d841d9c3839b12f15327/shellingham-1.5.0-py2.py3-none-any.whl
         sha256: a8f02ba61b69baaa13facdba62908ca8690a94b8119b69f5ec5873ea85f7391b
@@ -154,17 +209,17 @@ modules:
           packagetype: bdist_wheel
           type: pypi
       - type: file
-        url: https://files.pythonhosted.org/packages/d2/04/08841501db81bceb7a86a98dea7c12b0185fcc69bfdf1aea266f727d1d7e/poetry_core-1.0.8-py2.py3-none-any.whl
-        sha256: 54b0fab6f7b313886e547a52f8bf52b8cf43e65b2633c65117f8755289061924
-        x-checker-data:
-          name: poetry_core
-          packagetype: bdist_wheel
-          type: pypi
-      - type: file
         url: https://files.pythonhosted.org/packages/60/ef/7681134338fc097acef8d9b2f8abe0458e4d87559c689a8c306d0957ece5/requests_toolbelt-0.9.1-py2.py3-none-any.whl
         sha256: 380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f
         x-checker-data:
           name: requests_toolbelt
+          packagetype: bdist_wheel
+          type: pypi
+      - type: file
+        url: https://files.pythonhosted.org/packages/94/b3/ff2845971788613e646e667043fdb5f128e2e540aefa09a3c55be8290d6d/filelock-3.8.0-py3-none-any.whl
+        sha256: 617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4
+        x-checker-data:
+          name: filelock
           packagetype: bdist_wheel
           type: pypi
       - type: file
@@ -175,27 +230,6 @@ modules:
           packagetype: bdist_wheel
           type: pypi
       - type: file
-        url: https://files.pythonhosted.org/packages/f2/3d/4394c710b9195b83382dc67bdd1040e5ebfc3fc8df90e20fe74341298c57/clikit-0.6.2-py2.py3-none-any.whl
-        sha256: 71268e074e68082306e23d7369a7b99f824a0ef926e55ba2665e911f7208489e
-        x-checker-data:
-          name: clikit
-          packagetype: bdist_wheel
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/aa/18/a8444036c6dd65ba3624c63b734d3ba95ba63ace513078e1580590075d21/pastel-0.2.1-py2.py3-none-any.whl
-        sha256: 4349225fcdf6c2bb34d483e523475de5bb04a5c10ef711263452cb37d7dd4364
-        x-checker-data:
-          name: pastel
-          packagetype: bdist_wheel
-          type: pypi
-      - type: file
-        url: https://files.pythonhosted.org/packages/03/be/462969afb12c0254a23d5c1f8e357b4a9b8add7ffa79f7164139e8fd25ff/poetry-1.1.14-py2.py3-none-any.whl
-        sha256: fbd0b2536b730cd1d7a1fabb3a292a2cc423c5da3d59c4db44335a449f5acd9a
-        x-checker-data:
-          name: poetry
-          packagetype: bdist_wheel
-          type: pypi
-      - type: file
         url: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
         sha256: a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78
         x-checker-data:
@@ -203,10 +237,17 @@ modules:
           packagetype: bdist_wheel
           type: pypi
       - type: file
-        url: https://files.pythonhosted.org/packages/09/46/3577da4237675e90630e8e9ccd2c7dbcd42afd4463712a207eab148dfbc2/cleo-0.8.1-py2.py3-none-any.whl
-        sha256: 141cda6dc94a92343be626bb87a0b6c86ae291dfc732a57bf04310d4b4201753
+        url: https://files.pythonhosted.org/packages/18/31/2a87f292f752d39c6c207f9e44137e3e1d4250da880a9fbc0bbf630138e0/tomlkit-0.11.4-py3-none-any.whl
+        sha256: 25d4e2e446c453be6360c67ddfb88838cfc42026322770ba13d1fbd403a93a5c
         x-checker-data:
-          name: cleo
+          name: tomlkit
+          packagetype: bdist_wheel
+          type: pypi
+      - type: file
+        url: https://files.pythonhosted.org/packages/6f/de/5be2e3eed8426f871b170663333a0f627fc2924cc386cd41be065e7ea870/urllib3-1.26.12-py2.py3-none-any.whl
+        sha256: b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997
+        x-checker-data:
+          name: urllib3
           packagetype: bdist_wheel
           type: pypi
       - type: file
@@ -217,17 +258,17 @@ modules:
           packagetype: bdist_wheel
           type: pypi
       - type: file
-        url: https://files.pythonhosted.org/packages/94/69/64b11e8c2fb21f08634468caef885112e682b0ebe2908e74d3616eb1c113/charset_normalizer-2.1.0-py3-none-any.whl
-        sha256: 5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5
+        url: https://files.pythonhosted.org/packages/ea/43/5dfea5153589e7663e5606484e6af65a83b2f3f04cee1013753feb32d159/poetry-1.2.0-py3-none-any.whl
+        sha256: af99cad115cb0fbad8c41eb31c5a5dee25a9f6c74fc1d4d6dad8e51a69ebe348
         x-checker-data:
-          name: charset_normalizer
+          name: poetry
           packagetype: bdist_wheel
           type: pypi
       - type: file
-        url: https://files.pythonhosted.org/packages/d1/cb/4783c8f1a90f89e260dbf72ebbcf25931f3a28f8f80e2e90f8a589941b19/urllib3-1.26.11-py2.py3-none-any.whl
-        sha256: c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc
+        url: https://files.pythonhosted.org/packages/db/51/a507c856293ab05cdc1db77ff4bc1268ddd39f29e7dc4919aa497f0adbec/charset_normalizer-2.1.1-py3-none-any.whl
+        sha256: 83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f
         x-checker-data:
-          name: urllib3
+          name: charset_normalizer
           packagetype: bdist_wheel
           type: pypi
       - type: file
@@ -236,14 +277,14 @@ modules:
         x-checker-data:
           name: msgpack
           type: pypi
-      - *id003
       - type: file
-        url: https://files.pythonhosted.org/packages/db/7c/10e78bd85f92025abfc43d0f4360bc4aa48f7241d850426cc522352e183e/tomlkit-0.11.2-py3-none-any.whl
-        sha256: 69e0675671a2eed1c08a53f342c955c4ead5d373a10f756219bf39f3d4f0018a
+        url: https://files.pythonhosted.org/packages/f2/bc/d817287d1aa01878af07c19505fafd1165cd6a119e9d0821ca1d1c20312d/attrs-22.1.0-py2.py3-none-any.whl
+        sha256: 86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c
         x-checker-data:
-          name: tomlkit
+          name: attrs
           packagetype: bdist_wheel
           type: pypi
+      - *id003
       - type: file
         url: https://files.pythonhosted.org/packages/ae/72/2a1e2290f1ab1e06f71f3d0f1646c9e4634e70e1d37491535e19266e8dc9/jeepney-0.8.0-py3-none-any.whl
         sha256: c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755
@@ -284,6 +325,20 @@ modules:
         sha256: 8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349
         x-checker-data:
           name: requests
+          packagetype: bdist_wheel
+          type: pypi
+      - type: file
+        url: https://files.pythonhosted.org/packages/4f/8c/2f44bb00c152f24d980c91b95c0b0f38f814eb5b7a7da102467d23749ee3/virtualenv-20.16.4-py3-none-any.whl
+        sha256: 035ed57acce4ac35c82c9d8802202b0e71adac011a511ff650cbcf9635006a22
+        x-checker-data:
+          name: virtualenv
+          packagetype: bdist_wheel
+          type: pypi
+      - type: file
+        url: https://files.pythonhosted.org/packages/76/cb/6bbd2b10170ed991cf64e8c8b85e01f2fb38f95d1bc77617569e0b0b26ac/distlib-0.3.6-py2.py3-none-any.whl
+        sha256: f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e
+        x-checker-data:
+          name: distlib
           packagetype: bdist_wheel
           type: pypi
 name: python3-modules

--- a/python3-virtualenv.yaml
+++ b/python3-virtualenv.yaml
@@ -6,24 +6,10 @@ build-commands:
     --prefix=${FLATPAK_DEST} "virtualenv" --no-build-isolation
 sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/a6/d5/17f02b379525d1ff9678bfa58eb9548f561c8826deb0b85797aa0eed582d/filelock-3.7.1-py3-none-any.whl
-    sha256: 37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404
+    url: https://files.pythonhosted.org/packages/94/b3/ff2845971788613e646e667043fdb5f128e2e540aefa09a3c55be8290d6d/filelock-3.8.0-py3-none-any.whl
+    sha256: 617eb4e5eedc82fc5f47b6d61e4d11cb837c56cb4544e39081099fa17ad109d4
     x-checker-data:
       name: filelock
-      packagetype: bdist_wheel
-      type: pypi
-  - type: file
-    url: https://files.pythonhosted.org/packages/d5/94/db0229ff741c8ff2ff0ac5a8a58d142bd0f81c810701ad9eae2c4c718ede/distlib-0.3.5-py2.py3-none-any.whl
-    sha256: b710088c59f06338ca514800ad795a132da19fda270e3ce4affc74abf955a26c
-    x-checker-data:
-      name: distlib
-      packagetype: bdist_wheel
-      type: pypi
-  - type: file
-    url: https://files.pythonhosted.org/packages/c2/d2/e80b6ad57bc0727fe0bbe7d9c496bde4ef3008e57f452ed1bfafe6618d04/virtualenv-20.16.3-py2.py3-none-any.whl
-    sha256: 4193b7bc8a6cd23e4eb251ac64f29b4398ab2c233531e66e40b19a6b7b0d30c1
-    x-checker-data:
-      name: virtualenv
       packagetype: bdist_wheel
       type: pypi
   - type: file
@@ -31,5 +17,19 @@ sources:
     sha256: 027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788
     x-checker-data:
       name: platformdirs
+      packagetype: bdist_wheel
+      type: pypi
+  - type: file
+    url: https://files.pythonhosted.org/packages/4f/8c/2f44bb00c152f24d980c91b95c0b0f38f814eb5b7a7da102467d23749ee3/virtualenv-20.16.4-py3-none-any.whl
+    sha256: 035ed57acce4ac35c82c9d8802202b0e71adac011a511ff650cbcf9635006a22
+    x-checker-data:
+      name: virtualenv
+      packagetype: bdist_wheel
+      type: pypi
+  - type: file
+    url: https://files.pythonhosted.org/packages/76/cb/6bbd2b10170ed991cf64e8c8b85e01f2fb38f95d1bc77617569e0b0b26ac/distlib-0.3.6-py2.py3-none-any.whl
+    sha256: f35c4b692542ca110de7ef0bea44d73981caeb34ca0b9b6b2e6d7790dda8f80e
+    x-checker-data:
+      name: distlib
       packagetype: bdist_wheel
       type: pypi


### PR DESCRIPTION
Update poetry to latest release. 
Switch to latest cryptography.


Not sure if sdk-extensions is available on ci.
```
sdk-extensions:
  - org.freedesktop.Sdk.Extension.rust-stable
```

Also not sure if we should stick on old version of cryptography or add rust as build dependency.