### PR TITLE
Add libsecret

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.jetbrains.PyCharm-Professional.yaml
+++ b/com.jetbrains.PyCharm-Professional.yaml
@@ -26,6 +26,8 @@ add-extensions:
     subdirectories: true
     no-autodownload: true
 modules:
+  - shared-modules/libsecret/libsecret.json
+
   - python3-virtualenv.yaml
 
   - python3-pipenv.yaml


### PR DESCRIPTION
This is the equivalent of https://github.com/flathub/com.jetbrains.PyCharm-Community/pull/242 for PyCharm Professional (ten months late, sorry about that)

It adds libsecret from the shared modules to the flatpak, so that PyCharm can save credentials in the native keychain.

The permissions are already sufficient for libsecret to work, it just needs to be installed.