### PR TITLE
chore: Use Wayland by default

### DIFF
--- a/com.jetbrains.PyCharm-Professional.yaml
+++ b/com.jetbrains.PyCharm-Professional.yaml
@@ -15,7 +15,8 @@ finish-args:
   - --socket=pulseaudio
   - --socket=session-bus
   - --socket=ssh-auth
-  - --socket=x11
+  - --socket=fallback-x11
+  - --socket=wayland
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.freedesktop.FileManager1


### PR DESCRIPTION
Enable Wayland with X11 as fallback. Starting with 2026.1, IntelliJ-based IDEs will run natively on Wayland.
https://blog.jetbrains.com/platform/2026/02/wayland-by-default-in-2026-1-eap/

